### PR TITLE
feat: Add action to list NotificationHub keys to PagoPA IaC Reader 

### DIFF
--- a/src/01_custom_roles/01_iac_reader.tf
+++ b/src/01_custom_roles/01_iac_reader.tf
@@ -16,7 +16,8 @@ resource "azurerm_role_definition" "iac_reader" {
       "Microsoft.ServiceBus/namespaces/queues/authorizationRules/listKeys/action",
       "Microsoft.Cache/redis/listKeys/action",
       "Microsoft.Web/sites/host/listkeys/action",
-      "Microsoft.NotificationHubs/namespaces/notificationHubs/pnsCredentials/action", #list NotificationHub PNS credentials
+      "Microsoft.NotificationHubs/namespaces/notificationHubs/pnsCredentials/action",              #list NotificationHub PNS credentials
+      "Microsoft.NotificationHubs/namespaces/notificationHubs/authorizationRules/listKeys/action", #list NotificationHub keys
     ]
   }
 }


### PR DESCRIPTION
<!-- markdownlint-disable -->
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
Add action to list NotificationHub keys to PagoPA IaC Reader 

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Identities federated with CI pipelines needs to list credentials when the Notification Hub is versioned through Terraform

### Type of changes

- [X] Add new governance rule
- [ ] Update existing governance rule
- [ ] Remove existing governance rule

### Does this introduce a breaking change?

- [ ] Yes
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
