### PR TITLE
feat: Add Opex Contributor custom role

### DIFF
--- a/src/01_custom_roles/01_opex_contributor.tf
+++ b/src/01_custom_roles/01_opex_contributor.tf
@@ -1,5 +1,5 @@
-resource "azurerm_role_definition" "dx_opex_contributor" {
-  name        = "DX Opex Dashboards Contributor"
+resource "azurerm_role_definition" "opex_contributor" {
+  name        = "PagoPA Opex Dashboards Contributor"
   scope       = data.azurerm_management_group.pagopa.id
   description = "Role to manage the Opex Dashboards creation, modification and deletion"
 

--- a/src/01_custom_roles/01_opex_contributor.tf
+++ b/src/01_custom_roles/01_opex_contributor.tf
@@ -1,0 +1,13 @@
+resource "azurerm_role_definition" "dx_opex_contributor" {
+  name        = "DX Opex Dashboards Contributor"
+  scope       = data.azurerm_management_group.pagopa.id
+  description = "Role to manage the Opex Dashboards creation, modification and deletion"
+
+  permissions {
+    actions = [
+      "Microsoft.Portal/dashboards/write",
+      "Microsoft.Portal/dashboards/read",
+      "Microsoft.Portal/dashboards/delete",
+    ]
+  }
+}

--- a/src/01_custom_roles/README.md
+++ b/src/01_custom_roles/README.md
@@ -31,6 +31,7 @@ No modules.
 | [azurerm_role_definition.ddos_joiner](https://registry.terraform.io/providers/hashicorp/azurerm/3.77.0/docs/resources/role_definition) | resource |
 | [azurerm_role_definition.dns_takeover](https://registry.terraform.io/providers/hashicorp/azurerm/3.77.0/docs/resources/role_definition) | resource |
 | [azurerm_role_definition.dns_zone_reader](https://registry.terraform.io/providers/hashicorp/azurerm/3.77.0/docs/resources/role_definition) | resource |
+| [azurerm_role_definition.dx_opex_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/3.77.0/docs/resources/role_definition) | resource |
 | [azurerm_role_definition.export_deployments_template](https://registry.terraform.io/providers/hashicorp/azurerm/3.77.0/docs/resources/role_definition) | resource |
 | [azurerm_role_definition.iac_reader](https://registry.terraform.io/providers/hashicorp/azurerm/3.77.0/docs/resources/role_definition) | resource |
 | [azurerm_role_definition.log_analytics_table_reader](https://registry.terraform.io/providers/hashicorp/azurerm/3.77.0/docs/resources/role_definition) | resource |

--- a/src/01_custom_roles/README.md
+++ b/src/01_custom_roles/README.md
@@ -31,10 +31,10 @@ No modules.
 | [azurerm_role_definition.ddos_joiner](https://registry.terraform.io/providers/hashicorp/azurerm/3.77.0/docs/resources/role_definition) | resource |
 | [azurerm_role_definition.dns_takeover](https://registry.terraform.io/providers/hashicorp/azurerm/3.77.0/docs/resources/role_definition) | resource |
 | [azurerm_role_definition.dns_zone_reader](https://registry.terraform.io/providers/hashicorp/azurerm/3.77.0/docs/resources/role_definition) | resource |
-| [azurerm_role_definition.dx_opex_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/3.77.0/docs/resources/role_definition) | resource |
 | [azurerm_role_definition.export_deployments_template](https://registry.terraform.io/providers/hashicorp/azurerm/3.77.0/docs/resources/role_definition) | resource |
 | [azurerm_role_definition.iac_reader](https://registry.terraform.io/providers/hashicorp/azurerm/3.77.0/docs/resources/role_definition) | resource |
 | [azurerm_role_definition.log_analytics_table_reader](https://registry.terraform.io/providers/hashicorp/azurerm/3.77.0/docs/resources/role_definition) | resource |
+| [azurerm_role_definition.opex_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/3.77.0/docs/resources/role_definition) | resource |
 | [azurerm_role_definition.policy_exempt](https://registry.terraform.io/providers/hashicorp/azurerm/3.77.0/docs/resources/role_definition) | resource |
 | [azurerm_role_definition.policy_reader](https://registry.terraform.io/providers/hashicorp/azurerm/3.77.0/docs/resources/role_definition) | resource |
 | [azurerm_role_definition.policy_remediator](https://registry.terraform.io/providers/hashicorp/azurerm/3.77.0/docs/resources/role_definition) | resource |


### PR DESCRIPTION
<!-- markdownlint-disable -->
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

Add a new custom role at management group scope to manage OPEX dashboards.

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

Limit permissions to least privilege

### Type of changes

- [X] Add new governance rule
- [ ] Update existing governance rule
- [ ] Remove existing governance rule

### Does this introduce a breaking change?

- [ ] Yes
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

DX modules expect this role to be available in the subscription. As DX tooling can be consumed by any external contributor too, role name prefix is set to `DX` to do not limit its scope to PagoPA organization only. In fact, it would be weird for anyone to have a role named `PagoPA` in its own organization
