### PR TITLE
feat: Create custom role for storage queue triggers

### DIFF
--- a/src/01_custom_roles/01_storage_queue_trigger.tf
+++ b/src/01_custom_roles/01_storage_queue_trigger.tf
@@ -4,7 +4,7 @@ resource "azurerm_role_definition" "storage_queue_trigger" {
   description = "Role for managing visibility timeout of messages in storage queues"
 
   permissions {
-    actions = [
+    data_actions = [
       "Microsoft.Storage/storageAccounts/queueServices/queues/messages/write" # set visibility timeout of messages in storage queues
     ]
   }

--- a/src/01_custom_roles/01_storage_queue_trigger.tf
+++ b/src/01_custom_roles/01_storage_queue_trigger.tf
@@ -5,7 +5,9 @@ resource "azurerm_role_definition" "storage_queue_trigger" {
 
   permissions {
     data_actions = [
-      "Microsoft.Storage/storageAccounts/queueServices/queues/messages/write" # set visibility timeout of messages in storage queues
+      "Microsoft.Storage/storageAccounts/queueServices/queues/messages/write",         # set visibility timeout of messages in storage queues
+      "Microsoft.Storage/storageAccounts/queueServices/queues/messages/delete",        # delete messages in storage queues
+      "Microsoft.Storage/storageAccounts/queueServices/queues/messages/process/action" # process messages in storage queues
     ]
   }
 }

--- a/src/01_custom_roles/01_storage_queue_trigger.tf
+++ b/src/01_custom_roles/01_storage_queue_trigger.tf
@@ -1,0 +1,11 @@
+resource "azurerm_role_definition" "storage_queue_trigger" {
+  name        = "PagoPA Storage Queue Data Message Contributor"
+  scope       = data.azurerm_management_group.pagopa.id
+  description = "Role for managing visibility timeout of messages in storage queues"
+
+  permissions {
+    actions = [
+      "Microsoft.Storage/storageAccounts/queueServices/queues/messages/write" # set visibility timeout of messages in storage queues
+    ]
+  }
+}

--- a/src/01_custom_roles/README.md
+++ b/src/01_custom_roles/README.md
@@ -40,6 +40,7 @@ No modules.
 | [azurerm_role_definition.policy_remediator](https://registry.terraform.io/providers/hashicorp/azurerm/4.35.0/docs/resources/role_definition) | resource |
 | [azurerm_role_definition.resource_lock_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/4.35.0/docs/resources/role_definition) | resource |
 | [azurerm_role_definition.security_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/4.35.0/docs/resources/role_definition) | resource |
+| [azurerm_role_definition.storage_queue_trigger](https://registry.terraform.io/providers/hashicorp/azurerm/4.35.0/docs/resources/role_definition) | resource |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/4.35.0/docs/data-sources/client_config) | data source |
 | [azurerm_management_group.pagopa](https://registry.terraform.io/providers/hashicorp/azurerm/4.35.0/docs/data-sources/management_group) | data source |
 | [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/4.35.0/docs/data-sources/subscription) | data source |


### PR DESCRIPTION
<!-- markdownlint-disable -->
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
Added a new custom role that allows to write messages on storage accounts queues

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
A function app with a queue trigger does cannot set the visibility timeout without the highest azure-defined role `Storage Queue Data Contributor`.
To avoid assigning such highly permissive role to functions, a new custom role with minimal permissions is being proposed.

### Type of changes

- [ ] Add new governance rule
- [ ] Update existing governance rule
- [ ] Remove existing governance rule

### Does this introduce a breaking change?

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
