### PR TITLE
Define custom role to contribute on blobs tags

### DIFF
--- a/src/01_custom_roles/01_storage_blob_tags_contributor.tf
+++ b/src/01_custom_roles/01_storage_blob_tags_contributor.tf
@@ -1,0 +1,12 @@
+resource "azurerm_role_definition" "storage_blob_contributor" {
+  name        = "PagoPA Storage Blob Tags Contributor"
+  scope       = data.azurerm_management_group.pagopa.id
+  description = "Role for managing tags of blobs in storage"
+
+  permissions {
+    data_actions = [
+      "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/tags/read", # read tags of blobs in storage
+      "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/tags/write" # write tags of blobs in storage
+    ]
+  }
+}


### PR DESCRIPTION
<!-- markdownlint-disable -->
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
- Define custom role `PagoPA Storage Blob Tags Contributor` to contribute on blobs tags

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Developers with `Storage Blob Data Contributor` role, cannot write blobs with specific tags. The role, in fact, does not contain any permission about tags.
The new role's (`PagoPA Storage Blob Tags Contributor`) use is intended in combination with `Storage Blob Data Contributor`.

### Type of changes

- [ ] Add new governance rule
- [ ] Update existing governance rule
- [ ] Remove existing governance rule

### Does this introduce a breaking change?

- [ ] Yes
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
