### PR TITLE
feat: Add customdomains read permission to PagoPA DNS Takeover role

### DIFF
--- a/src/01_custom_roles/01_dns_takeover.tf
+++ b/src/01_custom_roles/01_dns_takeover.tf
@@ -9,6 +9,8 @@ resource "azurerm_role_definition" "dns_takeover" {
       "Microsoft.Network/frontDoors/read",
       "Microsoft.Storage/storageAccounts/read",
       "Microsoft.Cdn/profiles/endpoints/read",
+      "Microsoft.Cdn/profiles/customdomains/read",
+      "Microsoft.Cdn/profiles/endpoints/customdomains/read",
       "Microsoft.Cdn/profiles/afdendpoints/read",
       "Microsoft.Network/trafficManagerProfiles/read",
       "Microsoft.Network/publicIPAddresses/read",

--- a/src/01_custom_roles/01_dns_takeover.tf
+++ b/src/01_custom_roles/01_dns_takeover.tf
@@ -8,6 +8,7 @@ resource "azurerm_role_definition" "dns_takeover" {
       "Microsoft.Network/dnsZones/*/read",
       "Microsoft.Network/frontDoors/read",
       "Microsoft.Storage/storageAccounts/read",
+      "Microsoft.Cdn/profiles/read",
       "Microsoft.Cdn/profiles/endpoints/read",
       "Microsoft.Cdn/profiles/customdomains/read",
       "Microsoft.Cdn/profiles/endpoints/customdomains/read",


### PR DESCRIPTION
<!-- markdownlint-disable -->
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
This PR adds add Custom Domains CDN read permission to PagoPA DNS Takeover role.
<!--- Describe your changes in detail -->

### Motivation and context

The subdomain takeover must see also the CDN custom domains to avoid False Positive. 
<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new governance rule
- [X] Update existing governance rule
- [ ] Remove existing governance rule

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
