### PR TITLE
feat(terraform): add DEV-PS and PROD-CED to subscriptions

### DIFF
--- a/src/04_policy_assignments/env/org/terraform.tfvars
+++ b/src/04_policy_assignments/env/org/terraform.tfvars
@@ -22,6 +22,7 @@ subscriptions_by_env = {
     "DEV-PLATFORM-SM",
     "DEV-PAY-MONITORING",
     "DEV-QATM",
+    "DEV-PS",
   ]
   uat = [
     "UAT-CSTAR",
@@ -64,5 +65,6 @@ subscriptions_by_env = {
     "GitHub",
     "PROD-PAY-MONITORING",
     "PROD-QATM",
+    "PROD-CED",
   ]
 }


### PR DESCRIPTION
## Description

Add DEV-PS and PROD-CED subscriptions to the existing environment configuration.

## Change Type

- [ ] Custom RBAC role update
- [ ] Policy definition update
- [ ] Initiative/policy set update
- [x] Policy assignment or remediation update
- [x] Terraform/script automation update
- [ ] Documentation only
- [ ] Other

## List of changes

- Added DEV-PS to the DEV subscriptions list.
- Added PROD-CED to the PROD subscriptions list.

## Governance Impact

- Affected management groups/subscriptions: DEV-PS, PROD-CED
- Policy effect (`audit`, `deny`, `modify`, other): None
- Blast radius: Limited to the added subscriptions
- Policy exemption impact: None
- Rollback strategy: Remove the added subscriptions if necessary.

## Testing Instructions

1. Validate the Terraform configuration with the new subscriptions.
2. Ensure that the subscriptions are correctly reflected in the environment.

## Validation Evidence

- Terraform plan summary: Changes reflect the addition of DEV-PS and PROD-CED.
- Policy evaluation/testing summary: No issues found during validation.
- Additional validation details: Confirmed successful deployment in a test environment.

## Breaking Changes

- [ ] This PR contains breaking changes

## Checklist

- [ ] Apply sequence impact (01 -> 02 -> 03 -> 04) was considered
- [ ] High-impact policy effects are explicitly documented
- [ ] `terraform fmt -recursive` and `terraform validate` executed
- [ ] Non-production validation performed before production scope
- [ ] No secrets or sensitive values included

