### PR TITLE
feat: Create custom roles required by the DX subscription bootstrapper

### DIFF
--- a/src/01_custom_roles/01_dx_app_cd_resource_group_deploy.tf
+++ b/src/01_custom_roles/01_dx_app_cd_resource_group_deploy.tf
@@ -1,0 +1,14 @@
+module "dx_app_cd_resource_group_deploy" {
+  source = "git::https://github.com/pagopa/dx.git//infra/modules/azure_merge_roles?ref=implement-merge-roles-terraform-module"
+
+  scope       = data.azurerm_management_group.pagopa.id
+  role_name   = "PagoPA DX App CD Resource Group Deploy"
+  description = "Merged role for DX App CD identities at resource group scope"
+  source_roles = [
+    "Website Contributor",
+    "CDN Profile Contributor",
+    "Container Apps Contributor",
+    "Storage Blob Data Contributor",
+    azurerm_role_definition.static_web_app_secrets.name,
+  ]
+}

--- a/src/01_custom_roles/01_dx_app_cd_resource_group_deploy.tf
+++ b/src/01_custom_roles/01_dx_app_cd_resource_group_deploy.tf
@@ -1,9 +1,10 @@
 module "dx_app_cd_resource_group_deploy" {
-  source = "git::https://github.com/pagopa/dx.git//infra/modules/azure_merge_roles?ref=implement-merge-roles-terraform-module"
+  source  = "pagopa-dx/azure-merge-roles/azurerm"
+  version = "~> 0.0"
 
-  scope       = data.azurerm_management_group.pagopa.id
-  role_name   = "PagoPA DX App CD Resource Group Deploy"
-  description = "Merged role for DX App CD identities at resource group scope"
+  scope     = data.azurerm_management_group.pagopa.id
+  role_name = "PagoPA DX App CD Resource Group Deploy"
+  reason    = "Merged role for DX App CD identities at resource group scope"
   source_roles = [
     "Website Contributor",
     "CDN Profile Contributor",

--- a/src/01_custom_roles/01_dx_app_ci_resource_group_reader.tf
+++ b/src/01_custom_roles/01_dx_app_ci_resource_group_reader.tf
@@ -1,9 +1,10 @@
 module "dx_app_ci_resource_group_reader" {
-  source = "git::https://github.com/pagopa/dx.git//infra/modules/azure_merge_roles?ref=implement-merge-roles-terraform-module"
+  source  = "pagopa-dx/azure-merge-roles/azurerm"
+  version = "~> 0.0"
 
-  scope       = data.azurerm_management_group.pagopa.id
-  role_name   = "PagoPA DX App CI Resource Group Reader"
-  description = "Merged role for DX App CI identities at resource group scope"
+  scope     = data.azurerm_management_group.pagopa.id
+  role_name = "PagoPA DX App CI Resource Group Reader"
+  reason    = "Merged role for DX App CI identities at resource group scope"
   source_roles = [
     azurerm_role_definition.iac_reader.name,
     azurerm_role_definition.static_web_app_secrets.name,

--- a/src/01_custom_roles/01_dx_app_ci_resource_group_reader.tf
+++ b/src/01_custom_roles/01_dx_app_ci_resource_group_reader.tf
@@ -1,0 +1,11 @@
+module "dx_app_ci_resource_group_reader" {
+  source = "git::https://github.com/pagopa/dx.git//infra/modules/azure_merge_roles?ref=implement-merge-roles-terraform-module"
+
+  scope       = data.azurerm_management_group.pagopa.id
+  role_name   = "PagoPA DX App CI Resource Group Reader"
+  description = "Merged role for DX App CI identities at resource group scope"
+  source_roles = [
+    azurerm_role_definition.iac_reader.name,
+    azurerm_role_definition.static_web_app_secrets.name,
+  ]
+}

--- a/src/01_custom_roles/01_dx_infra_cd_private_networking.tf
+++ b/src/01_custom_roles/01_dx_infra_cd_private_networking.tf
@@ -1,0 +1,11 @@
+module "dx_infra_cd_private_networking" {
+  source = "git::https://github.com/pagopa/dx.git//infra/modules/azure_merge_roles?ref=implement-merge-roles-terraform-module"
+
+  scope       = data.azurerm_management_group.pagopa.id
+  role_name   = "PagoPA DX Infra CD Private Networking"
+  description = "Merged role for DX Infra CD identities managing private DNS networking"
+  source_roles = [
+    "Private DNS Zone Contributor",
+    "Network Contributor",
+  ]
+}

--- a/src/01_custom_roles/01_dx_infra_cd_private_networking.tf
+++ b/src/01_custom_roles/01_dx_infra_cd_private_networking.tf
@@ -1,9 +1,10 @@
 module "dx_infra_cd_private_networking" {
-  source = "git::https://github.com/pagopa/dx.git//infra/modules/azure_merge_roles?ref=implement-merge-roles-terraform-module"
+  source  = "pagopa-dx/azure-merge-roles/azurerm"
+  version = "~> 0.0"
 
-  scope       = data.azurerm_management_group.pagopa.id
-  role_name   = "PagoPA DX Infra CD Private Networking"
-  description = "Merged role for DX Infra CD identities managing private DNS networking"
+  scope     = data.azurerm_management_group.pagopa.id
+  role_name = "PagoPA DX Infra CD Private Networking"
+  reason    = "Merged role for DX Infra CD identities managing private DNS networking"
   source_roles = [
     "Private DNS Zone Contributor",
     "Network Contributor",

--- a/src/01_custom_roles/01_dx_infra_cd_resource_group_deploy.tf
+++ b/src/01_custom_roles/01_dx_infra_cd_resource_group_deploy.tf
@@ -1,0 +1,18 @@
+module "dx_infra_cd_resource_group_deploy" {
+  source = "git::https://github.com/pagopa/dx.git//infra/modules/azure_merge_roles?ref=implement-merge-roles-terraform-module"
+
+  scope       = data.azurerm_management_group.pagopa.id
+  role_name   = "PagoPA DX Infra CD Resource Group Deploy"
+  description = "Merged role for DX Infra CD identities at resource group scope"
+  source_roles = [
+    "Contributor",
+    "User Access Administrator",
+    "Key Vault Secrets Officer",
+    "Key Vault Certificates Officer",
+    "Key Vault Crypto Officer",
+    "Storage Blob Data Contributor",
+    "Storage Queue Data Contributor",
+    "Storage Table Data Contributor",
+    "Container Apps Contributor",
+  ]
+}

--- a/src/01_custom_roles/01_dx_infra_cd_resource_group_deploy.tf
+++ b/src/01_custom_roles/01_dx_infra_cd_resource_group_deploy.tf
@@ -1,9 +1,10 @@
 module "dx_infra_cd_resource_group_deploy" {
-  source = "git::https://github.com/pagopa/dx.git//infra/modules/azure_merge_roles?ref=implement-merge-roles-terraform-module"
+  source  = "pagopa-dx/azure-merge-roles/azurerm"
+  version = "~> 0.0"
 
-  scope       = data.azurerm_management_group.pagopa.id
-  role_name   = "PagoPA DX Infra CD Resource Group Deploy"
-  description = "Merged role for DX Infra CD identities at resource group scope"
+  scope     = data.azurerm_management_group.pagopa.id
+  role_name = "PagoPA DX Infra CD Resource Group Deploy"
+  reason    = "Merged role for DX Infra CD identities at resource group scope"
   source_roles = [
     "Contributor",
     "User Access Administrator",

--- a/src/01_custom_roles/01_dx_infra_cd_subscription_admin.tf
+++ b/src/01_custom_roles/01_dx_infra_cd_subscription_admin.tf
@@ -1,9 +1,10 @@
 module "dx_infra_cd_subscription_admin" {
-  source = "git::https://github.com/pagopa/dx.git//infra/modules/azure_merge_roles?ref=implement-merge-roles-terraform-module"
+  source  = "pagopa-dx/azure-merge-roles/azurerm"
+  version = "~> 0.0"
 
-  scope       = data.azurerm_management_group.pagopa.id
-  role_name   = "PagoPA DX Infra CD Subscription Admin"
-  description = "Merged role for DX Infra CD identities at subscription scope"
+  scope     = data.azurerm_management_group.pagopa.id
+  role_name = "PagoPA DX Infra CD Subscription Admin"
+  reason    = "Merged role for DX Infra CD identities at subscription scope"
   source_roles = [
     "Reader",
     "Role Based Access Control Administrator",

--- a/src/01_custom_roles/01_dx_infra_cd_subscription_admin.tf
+++ b/src/01_custom_roles/01_dx_infra_cd_subscription_admin.tf
@@ -1,0 +1,11 @@
+module "dx_infra_cd_subscription_admin" {
+  source = "git::https://github.com/pagopa/dx.git//infra/modules/azure_merge_roles?ref=implement-merge-roles-terraform-module"
+
+  scope       = data.azurerm_management_group.pagopa.id
+  role_name   = "PagoPA DX Infra CD Subscription Admin"
+  description = "Merged role for DX Infra CD identities at subscription scope"
+  source_roles = [
+    "Reader",
+    "Role Based Access Control Administrator",
+  ]
+}

--- a/src/01_custom_roles/01_dx_infra_ci_resource_group_reader.tf
+++ b/src/01_custom_roles/01_dx_infra_ci_resource_group_reader.tf
@@ -1,0 +1,18 @@
+module "dx_infra_ci_resource_group_reader" {
+  source = "git::https://github.com/pagopa/dx.git//infra/modules/azure_merge_roles?ref=implement-merge-roles-terraform-module"
+
+  scope       = data.azurerm_management_group.pagopa.id
+  role_name   = "PagoPA DX Infra CI Resource Group Reader"
+  description = "Merged role for DX Infra CI identities at resource group scope"
+  source_roles = [
+    "DocumentDB Account Contributor",
+    "Key Vault Secrets User",
+    "Key Vault Certificate User",
+    "Key Vault Crypto Officer",
+    "Storage Blob Data Reader",
+    "Storage Queue Data Reader",
+    "Storage Table Data Reader",
+    "Container Apps Operator",
+    "Container Apps Jobs Operator",
+  ]
+}

--- a/src/01_custom_roles/01_dx_infra_ci_resource_group_reader.tf
+++ b/src/01_custom_roles/01_dx_infra_ci_resource_group_reader.tf
@@ -1,9 +1,10 @@
 module "dx_infra_ci_resource_group_reader" {
-  source = "git::https://github.com/pagopa/dx.git//infra/modules/azure_merge_roles?ref=implement-merge-roles-terraform-module"
+  source  = "pagopa-dx/azure-merge-roles/azurerm"
+  version = "~> 0.0"
 
-  scope       = data.azurerm_management_group.pagopa.id
-  role_name   = "PagoPA DX Infra CI Resource Group Reader"
-  description = "Merged role for DX Infra CI identities at resource group scope"
+  scope     = data.azurerm_management_group.pagopa.id
+  role_name = "PagoPA DX Infra CI Resource Group Reader"
+  reason    = "Merged role for DX Infra CI identities at resource group scope"
   source_roles = [
     "DocumentDB Account Contributor",
     "Key Vault Secrets User",

--- a/src/01_custom_roles/01_dx_infra_ci_subscription_reader.tf
+++ b/src/01_custom_roles/01_dx_infra_ci_subscription_reader.tf
@@ -1,9 +1,10 @@
 module "dx_infra_ci_subscription_reader" {
-  source = "git::https://github.com/pagopa/dx.git//infra/modules/azure_merge_roles?ref=implement-merge-roles-terraform-module"
+  source  = "pagopa-dx/azure-merge-roles/azurerm"
+  version = "~> 0.0"
 
-  scope       = data.azurerm_management_group.pagopa.id
-  role_name   = "PagoPA DX Infra CI Subscription Reader"
-  description = "Merged role for DX Infra CI identities at subscription scope"
+  scope     = data.azurerm_management_group.pagopa.id
+  role_name = "PagoPA DX Infra CI Subscription Reader"
+  reason    = "Merged role for DX Infra CI identities at subscription scope"
   source_roles = [
     "Reader",
     "Reader and Data Access",

--- a/src/01_custom_roles/01_dx_infra_ci_subscription_reader.tf
+++ b/src/01_custom_roles/01_dx_infra_ci_subscription_reader.tf
@@ -1,0 +1,12 @@
+module "dx_infra_ci_subscription_reader" {
+  source = "git::https://github.com/pagopa/dx.git//infra/modules/azure_merge_roles?ref=implement-merge-roles-terraform-module"
+
+  scope       = data.azurerm_management_group.pagopa.id
+  role_name   = "PagoPA DX Infra CI Subscription Reader"
+  description = "Merged role for DX Infra CI identities at subscription scope"
+  source_roles = [
+    "Reader",
+    "Reader and Data Access",
+    azurerm_role_definition.iac_reader.name,
+  ]
+}

--- a/src/01_custom_roles/README.md
+++ b/src/01_custom_roles/README.md
@@ -25,13 +25,13 @@ This custom role allows the sp or users it is associated with to be able to laun
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_dx_app_cd_resource_group_deploy"></a> [dx\_app\_cd\_resource\_group\_deploy](#module\_dx\_app\_cd\_resource\_group\_deploy) | git::https://github.com/pagopa/dx.git//infra/modules/azure_merge_roles | implement-merge-roles-terraform-module |
-| <a name="module_dx_app_ci_resource_group_reader"></a> [dx\_app\_ci\_resource\_group\_reader](#module\_dx\_app\_ci\_resource\_group\_reader) | git::https://github.com/pagopa/dx.git//infra/modules/azure_merge_roles | implement-merge-roles-terraform-module |
-| <a name="module_dx_infra_cd_private_networking"></a> [dx\_infra\_cd\_private\_networking](#module\_dx\_infra\_cd\_private\_networking) | git::https://github.com/pagopa/dx.git//infra/modules/azure_merge_roles | implement-merge-roles-terraform-module |
-| <a name="module_dx_infra_cd_resource_group_deploy"></a> [dx\_infra\_cd\_resource\_group\_deploy](#module\_dx\_infra\_cd\_resource\_group\_deploy) | git::https://github.com/pagopa/dx.git//infra/modules/azure_merge_roles | implement-merge-roles-terraform-module |
-| <a name="module_dx_infra_cd_subscription_admin"></a> [dx\_infra\_cd\_subscription\_admin](#module\_dx\_infra\_cd\_subscription\_admin) | git::https://github.com/pagopa/dx.git//infra/modules/azure_merge_roles | implement-merge-roles-terraform-module |
-| <a name="module_dx_infra_ci_resource_group_reader"></a> [dx\_infra\_ci\_resource\_group\_reader](#module\_dx\_infra\_ci\_resource\_group\_reader) | git::https://github.com/pagopa/dx.git//infra/modules/azure_merge_roles | implement-merge-roles-terraform-module |
-| <a name="module_dx_infra_ci_subscription_reader"></a> [dx\_infra\_ci\_subscription\_reader](#module\_dx\_infra\_ci\_subscription\_reader) | git::https://github.com/pagopa/dx.git//infra/modules/azure_merge_roles | implement-merge-roles-terraform-module |
+| <a name="module_dx_app_cd_resource_group_deploy"></a> [dx\_app\_cd\_resource\_group\_deploy](#module\_dx\_app\_cd\_resource\_group\_deploy) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.0 |
+| <a name="module_dx_app_ci_resource_group_reader"></a> [dx\_app\_ci\_resource\_group\_reader](#module\_dx\_app\_ci\_resource\_group\_reader) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.0 |
+| <a name="module_dx_infra_cd_private_networking"></a> [dx\_infra\_cd\_private\_networking](#module\_dx\_infra\_cd\_private\_networking) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.0 |
+| <a name="module_dx_infra_cd_resource_group_deploy"></a> [dx\_infra\_cd\_resource\_group\_deploy](#module\_dx\_infra\_cd\_resource\_group\_deploy) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.0 |
+| <a name="module_dx_infra_cd_subscription_admin"></a> [dx\_infra\_cd\_subscription\_admin](#module\_dx\_infra\_cd\_subscription\_admin) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.0 |
+| <a name="module_dx_infra_ci_resource_group_reader"></a> [dx\_infra\_ci\_resource\_group\_reader](#module\_dx\_infra\_ci\_resource\_group\_reader) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.0 |
+| <a name="module_dx_infra_ci_subscription_reader"></a> [dx\_infra\_ci\_subscription\_reader](#module\_dx\_infra\_ci\_subscription\_reader) | pagopa-dx/azure-merge-roles/azurerm | ~> 0.0 |
 
 ## Resources
 

--- a/src/01_custom_roles/README.md
+++ b/src/01_custom_roles/README.md
@@ -23,7 +23,15 @@ This custom role allows the sp or users it is associated with to be able to laun
 
 ## Modules
 
-No modules.
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_dx_app_cd_resource_group_deploy"></a> [dx\_app\_cd\_resource\_group\_deploy](#module\_dx\_app\_cd\_resource\_group\_deploy) | git::https://github.com/pagopa/dx.git//infra/modules/azure_merge_roles | implement-merge-roles-terraform-module |
+| <a name="module_dx_app_ci_resource_group_reader"></a> [dx\_app\_ci\_resource\_group\_reader](#module\_dx\_app\_ci\_resource\_group\_reader) | git::https://github.com/pagopa/dx.git//infra/modules/azure_merge_roles | implement-merge-roles-terraform-module |
+| <a name="module_dx_infra_cd_private_networking"></a> [dx\_infra\_cd\_private\_networking](#module\_dx\_infra\_cd\_private\_networking) | git::https://github.com/pagopa/dx.git//infra/modules/azure_merge_roles | implement-merge-roles-terraform-module |
+| <a name="module_dx_infra_cd_resource_group_deploy"></a> [dx\_infra\_cd\_resource\_group\_deploy](#module\_dx\_infra\_cd\_resource\_group\_deploy) | git::https://github.com/pagopa/dx.git//infra/modules/azure_merge_roles | implement-merge-roles-terraform-module |
+| <a name="module_dx_infra_cd_subscription_admin"></a> [dx\_infra\_cd\_subscription\_admin](#module\_dx\_infra\_cd\_subscription\_admin) | git::https://github.com/pagopa/dx.git//infra/modules/azure_merge_roles | implement-merge-roles-terraform-module |
+| <a name="module_dx_infra_ci_resource_group_reader"></a> [dx\_infra\_ci\_resource\_group\_reader](#module\_dx\_infra\_ci\_resource\_group\_reader) | git::https://github.com/pagopa/dx.git//infra/modules/azure_merge_roles | implement-merge-roles-terraform-module |
+| <a name="module_dx_infra_ci_subscription_reader"></a> [dx\_infra\_ci\_subscription\_reader](#module\_dx\_infra\_ci\_subscription\_reader) | git::https://github.com/pagopa/dx.git//infra/modules/azure_merge_roles | implement-merge-roles-terraform-module |
 
 ## Resources
 


### PR DESCRIPTION
<!-- markdownlint-disable-file MD041 -->
<!-- PR title format: <type>(<scope>): <summary> -->
<!-- Examples: feat(terraform): add new SCP policy -->
<!--           fix(scripts): correct JSON validation logic -->

## Description

<!-- Describe the policy/custom role/initiative change and intended control. -->
The custom roles created in this PR are the result of the merge of azure built-in roles required by DX CI/CD workflows and terraform modules. The objective is to reduce the number of role assignments in the PROD-IO subscription.

More information can be found in the DevEx confluence space inside the "Riduzione role assignments su PROD-IO" brainstorming document.

Resolves CES-1956
Depends on https://github.com/pagopa/dx/pull/1648
## Change Type

- [X] Custom RBAC role update
- [ ] Policy definition update
- [ ] Initiative/policy set update
- [ ] Policy assignment or remediation update
- [ ] Terraform/script automation update
- [ ] Documentation only
- [ ] Other

## List of changes

- <!-- Brief summary of changes -->

## Governance Impact

- Affected management groups/subscriptions:
- Policy effect (`audit`, `deny`, `modify`, other):
- Blast radius:
- Policy exemption impact:
- Rollback strategy:

## Testing Instructions

<!-- Step-by-step instructions for reviewers to validate changes -->
1.
2.

## Validation Evidence

- Terraform plan summary:
- Policy evaluation/testing summary:
- Additional validation details:

## Breaking Changes

- [ ] This PR contains breaking changes
<!-- If checked, describe what breaks and migration path -->

## Checklist

- [ ] Apply sequence impact (01 -> 02 -> 03 -> 04) was considered
- [ ] High-impact policy effects are explicitly documented
- [ ] `terraform fmt -recursive` and `terraform validate` executed
- [ ] Non-production validation performed before production scope
- [ ] No secrets or sensitive values included
