### PR TITLE
feat(terraform): add filter action

### DIFF
--- a/src/01_custom_roles/01_storage_blob_tags_contributor.tf
+++ b/src/01_custom_roles/01_storage_blob_tags_contributor.tf
@@ -5,8 +5,9 @@ resource "azurerm_role_definition" "storage_blob_tags_contributor" {
 
   permissions {
     data_actions = [
-      "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/tags/read", # read tags of blobs in storage
-      "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/tags/write" # write tags of blobs in storage
+      "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/tags/read",    # read tags of blobs in storage
+      "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/tags/write",   # write tags of blobs in storage
+      "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/filter/action" # filter tags of blobs in storage
     ]
   }
 }


### PR DESCRIPTION
## Description

Add a filter action to the custom RBAC role for managing blob tags in Azure Storage.

## Change Type

- [x] Custom RBAC role update
- [ ] Policy definition update
- [ ] Initiative/policy set update
- [ ] Policy assignment or remediation update
- [ ] Terraform/script automation update
- [ ] Documentation only
- [ ] Other

## List of changes

- Added a filter action for blob tags in the storage role definition.

## Governance Impact

- Affected management groups/subscriptions: 
- Policy effect (`audit`, `deny`, `modify`, other): 
- Blast radius: 
- Policy exemption impact: 
- Rollback strategy: 

## Testing Instructions

1. Validate the role definition in the Azure portal.
2. Test the filter action functionality with blob tags.

## Validation Evidence

- Terraform plan summary: 
- Policy evaluation/testing summary: 
- Additional validation details: 

## Breaking Changes

- [ ] This PR contains breaking changes

## Checklist

- [ ] Apply sequence impact (01 -> 02 -> 03 -> 04) was considered
- [ ] High-impact policy effects are explicitly documented
- [x] `terraform fmt -recursive` and `terraform validate` executed
- [ ] Non-production validation performed before production scope
- [x] No secrets or sensitive values included

