### PR TITLE
fix: exclude AKS from resource lock policy for Azure Monitor extension migration

### DIFF
--- a/src/02_policy_resource_lock/01_resource_lock.tf
+++ b/src/02_policy_resource_lock/01_resource_lock.tf
@@ -14,7 +14,7 @@ variable "resource_lock_types" {
     "Microsoft.Network/virtualNetworkGateways",
     "Microsoft.OperationalInsights/workspaces",
     "microsoft.insights/components",
-    "Microsoft.ContainerService/ManagedClusters",
+    #"Microsoft.ContainerService/ManagedClusters",  Exclude AKS for Microsoft action migration for Azure Monitor extension (https://pagopa.atlassian.net/wiki/spaces/CSG/pages/3177349130/Azure+-+Disable+Resource+lock+policy)
     "Microsoft.Cdn/profiles",
     "Microsoft.KeyVault/vaults",
     "Microsoft.EventHub/Namespaces",


### PR DESCRIPTION
## Description

<!-- Describe the policy/custom role/initiative change and intended control. -->

## Change Type

- [ ] Custom RBAC role update
- [ ] Policy definition update
- [ ] Initiative/policy set update
- [ ] Policy assignment or remediation update
- [ ] Terraform/script automation update
- [ ] Documentation only
- [ ] Other

## List of changes

- <!-- Brief summary of changes -->

## Governance Impact

- Affected management groups/subscriptions:
- Policy effect (`audit`, `deny`, `modify`, other):
- Blast radius:
- Policy exemption impact:
- Rollback strategy:

## Testing Instructions

<!-- Step-by-step instructions for reviewers to validate changes -->
1.
2.

## Validation Evidence

- Terraform plan summary:
- Policy evaluation/testing summary:
- Additional validation details:

## Breaking Changes

- [ ] This PR contains breaking changes
<!-- If checked, describe what breaks and migration path -->

## Checklist

- [ ] Apply sequence impact (01 -> 02 -> 03 -> 04) was considered
- [ ] High-impact policy effects are explicitly documented
- [ ] `terraform fmt -recursive` and `terraform validate` executed
- [ ] Non-production validation performed before production scope
- [ ] No secrets or sensitive values included
