### PR TITLE
chore: restore Copilot agent settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,8 @@
   "github.copilot.enable": {
     "*": true
   },
+  "chat.useInstructionFiles": false,
+  "chat.useAgentsMdFile": true,
   "editor.formatOnSave": true,
   "editor.tabSize": 2,
   "[terraform]": {


### PR DESCRIPTION
## Description

Clean replacement for contaminated PR #223. This PR contains only the repository Copilot configuration needed to use `AGENTS.md` as the active instruction source.

## Change Type

- [ ] Custom RBAC role update
- [ ] Policy definition update
- [ ] Initiative/policy set update
- [ ] Policy assignment or remediation update
- [ ] Terraform/script automation update
- [x] Documentation only
- [x] Other

## List of changes

- Added exact `chat.useInstructionFiles: false` and `chat.useAgentsMdFile: true` settings to `.vscode/settings.json`.
- Preserved the existing single `## graphify` section in root `AGENTS.md`.
- Confirmed tracked `.github/copilot-instructions.md` contains no `## graphify` section.
- No Azure retirements implementation changes are included.

## Governance Impact

- Affected management groups/subscriptions: None.
- Policy effect (`audit`, `deny`, `modify`, other): None.
- Blast radius: Repository-local Copilot instruction loading only.
- Policy exemption impact: None.
- Rollback strategy: Revert the single `.vscode/settings.json` commit.

## Testing Instructions

<!-- Step-by-step instructions for reviewers to validate changes -->
1. Parse `.vscode/settings.json` as JSON and verify both exact boolean values.
2. Verify root `AGENTS.md` has exactly one `## graphify` section and the tracked projection has zero.
3. Confirm the diff from `main` contains only `.vscode/settings.json`.

## Validation Evidence

- Terraform plan summary: N/A.
- Policy evaluation/testing summary: N/A.
- Additional validation details: Exact configuration assertions passed; `git diff --check` passed; cached and committed changed-path checks passed. The repository-owned Copilot validator ran but reports 75 pre-existing baseline errors and 1 warning in unrelated prompts, inventory, and workflow metadata; no changed file is implicated.

## Breaking Changes

- [ ] This PR contains breaking changes

## Checklist

- [ ] Apply sequence impact (01 -> 02 -> 03 -> 04) was considered
- [ ] High-impact policy effects are explicitly documented
- [ ] `terraform fmt -recursive` and `terraform validate` executed
- [x] Non-production validation performed before production scope
- [x] No secrets or sensitive values included
